### PR TITLE
Avoid sending a second `EHLO` if no `STARTTLS`.

### DIFF
--- a/Transport/Smtp.php
+++ b/Transport/Smtp.php
@@ -222,7 +222,7 @@ class Smtp implements ITransport\Out
 
             if (true !== $client->enableEncryption(true, $client::ENCRYPTION_TLS)) {
                 throw new Mail\Exception\Transport(
-                    'Cannot start a TLS connection.',
+                    'Cannot enable a TLS connection.',
                     1
                 );
             }

--- a/Transport/Smtp.php
+++ b/Transport/Smtp.php
@@ -226,10 +226,11 @@ class Smtp implements ITransport\Out
                     1
                 );
             }
+
+            $client->writeAll('EHLO ' . $domain . CRLF);
+            $ehlo = preg_split('#' . CRLF . '250[\-\s]+#', $client->read(2048));
         }
 
-        $client->writeAll('EHLO ' . $domain . CRLF);
-        $ehlo    = preg_split('#' . CRLF . '250[\-\s]+#', $client->read(2048));
         $matches = null;
 
         foreach ($ehlo as $entry) {


### PR DESCRIPTION
In the case the server does not support `STARTTLS`, we always re-sent a new `EHLO`. While this operation is mandatory (see RFC3207, Section 4.2) if we switched to TLS, it is totally useless in the case no `STARTTLS` command has been sent. So move the new `EHLO` in the `STARTTLS` block. It will speed mail sending in the case `STARTTLS` is not supported by the server.