### PR TITLE
Better line reading and timeout support

### DIFF
--- a/Transport/Smtp.php
+++ b/Transport/Smtp.php
@@ -214,7 +214,7 @@ class Smtp implements ITransport\Out
             }
 
             $out[] = rtrim($matches['message']);
-        } while('-' === $matches['separator']);
+        } while ('-' === $matches['separator']);
 
         if (1 === count($out)) {
             return $out[0];

--- a/Transport/Smtp.php
+++ b/Transport/Smtp.php
@@ -168,9 +168,9 @@ class Smtp implements ITransport\Out
      * Check if the client replied correctly. If not, throw an exception
      * containing an error message.
      *
-     * @param   int     $code              Expected code.
-     * @param   string  $errorMessage      Error message if $code is not valid.
-     * @param   string  $timeOutMessage    Time out message.
+     * @param   int       $code              Expected code.
+     * @param   string    $errorMessage      Error message if $code is not valid.
+     * @param   string    $timeOutMessage    Time out message.
      * @return  string|array
      * @throws  \Hoa\Mail\Exception\Transport
      */

--- a/Transport/Smtp.php
+++ b/Transport/Smtp.php
@@ -168,6 +168,8 @@ class Smtp implements ITransport\Out
      * Check if the client replied correctly. If not, throw an exception
      * containing an error message.
      *
+     * @param   int     $code              Expected code.
+     * @param   string  $errorMessage      Error message if $code is not valid.
      * @return  bool
      * @throws  \Hoa\Mail\Exception\Transport
      */

--- a/Transport/Smtp.php
+++ b/Transport/Smtp.php
@@ -225,6 +225,8 @@ class Smtp implements ITransport\Out
 
     /**
      * Send a message.
+     * Timeouts are defined as the RFC2821 Section 4.5.3.2 suggests.
+     *
      * @TODO: Implement the DIGEST-MD5 and GSSAPI auth protocol. Implement SSLv1
      * and v2 support.
      *

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type"       : "library",
     "keywords"   : ["library", "mail", "smtp", "sendmail", "imap", "rfc2111",
                     "rfc4648", "rfc2045", "rfc2047", "rfc2104", "rfc2487",
-                    "rfc3207"],
+                    "rfc3207", "rfc2821"],
     "homepage"   : "http://hoa-project.net/",
     "license"    : "BSD-3-Clause",
     "authors"    : [


### PR DESCRIPTION
Fix #21.

Line reading:
  * The `ifNot` method now returns a line as a string or many lines as
    an array,
  * A line is read by using `Hoa\Socket\Connection::readLine` everytime,
    no more `Hoa\Socket\Connection::read` calls,
  * A set of lines is read thanks to the “code message separator” (for
    instance `250 Foo` represents the last line of the response while
    `250-Foo` indicates there is other lines to read in the response).

Timeout:
  * Timeout is checked after each received line,
  * An exception is thrown with a specific message if the connection
    timed out.