### PR TITLE
Composer: Fix dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,10 +25,11 @@
     "require": {
         "hoa/consistency": "~1.0",
         "hoa/exception"  : "~1.0",
-        "hoa/mime"       : "~3.0"
+        "hoa/mime"       : "~3.0",
+        "hoa/socket"     : "~1.0"
     },
     "require-dev": {
-        "hoa/file": "~0.0",
+        "hoa/file": "~1.0",
         "hoa/test": "~2.0"
     },
     "autoload": {


### PR DESCRIPTION
Fix #33.

`hoa/socket` is now mandatory and `hoa/file` is upgraded to `~1.0` in dev-dependencies.